### PR TITLE
Release/v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-Since version 2.0.0, the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
@@ -10,12 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Removed
 
+## [2.0.1] - 2024-11-21
+- COVERAGE:  95.50% -- 106/111 lines in 6 files
+- BRANCH COVERAGE:  84.00% -- 21/25 branches in 6 files
+- 44.83% documented
+### Added
+- More tests lifted from Rails v8.0 test suite
+### Fixed
+- Compatibility with ActiveSupport
+  - Many libraries do `require "active_support"`
+
 ## [2.0.0] - 2024-11-21
 - COVERAGE:  95.50% -- 106/111 lines in 6 files
 - BRANCH COVERAGE:  84.00% -- 21/25 branches in 6 files
 - 44.83% documented
 ### Added
-- Tests lifted from Rails v8.0 test suite.
+- Tests lifted from Rails v8.0 test suite
 - `ActiveSupport::LoggerSilence`
 - `ActiveSupport::IsolatedExecutionState`
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    activesupport-logger (2.0.0)
+    activesupport-logger (2.0.1)
       activesupport (>= 5.2)
       backports (~> 3.25, >= 3.25.0)
       logger (~> 1.6, >= 1.6.1)

--- a/REEK
+++ b/REEK
@@ -1,17 +1,11 @@
+spec/activesupport/logger_silence_spec.rb -- 1 warning:
+  [4]:IrresponsibleModule: MyLogger has no descriptive comment [https://github.com/troessner/reek/blob/v6.3.0/docs/Irresponsible-Module.md]
 spec/activesupport/logger_spec.rb -- 1 warning:
-  [450, 450]:DuplicateMethodCall: assert_level calls '@logger.level' 2 times [https://github.com/troessner/reek/blob/v6.3.0/docs/Duplicate-Method-Call.md]
+  [457, 457]:DuplicateMethodCall: assert_level calls '@logger.level' 2 times [https://github.com/troessner/reek/blob/v6.3.0/docs/Duplicate-Method-Call.md]
 spec/support/helpers/multibyte_test_helpers.rb -- 3 warnings:
   [1]:IrresponsibleModule: MultibyteTestHelpers has no descriptive comment [https://github.com/troessner/reek/blob/v6.3.0/docs/Irresponsible-Module.md]
   [6]:UtilityFunction: MultibyteTestHelpers#chars doesn't depend on instance state (maybe move it to another class?) [https://github.com/troessner/reek/blob/v6.3.0/docs/Utility-Function.md]
   [10]:UtilityFunction: MultibyteTestHelpers#inspect_codepoints doesn't depend on instance state (maybe move it to another class?) [https://github.com/troessner/reek/blob/v6.3.0/docs/Utility-Function.md]
-spec/vendor/activesupport/broadcast_logger.rb -- 7 warnings:
-  [79]:Attribute: ActiveSupport::BroadcastLogger#progname is a writable attribute [https://github.com/troessner/reek/blob/v6.3.0/docs/Attribute.md]
-  [208, 210, 211, 213]:FeatureEnvy: ActiveSupport::BroadcastLogger#method_missing refers to 'loggers' more than self (maybe move it to another class?) [https://github.com/troessner/reek/blob/v6.3.0/docs/Feature-Envy.md]
-  [199]:ManualDispatch: ActiveSupport::BroadcastLogger#dispatch manually dispatches method call [https://github.com/troessner/reek/blob/v6.3.0/docs/Manual-Dispatch.md]
-  [206]:ManualDispatch: ActiveSupport::BroadcastLogger#method_missing manually dispatches method call [https://github.com/troessner/reek/blob/v6.3.0/docs/Manual-Dispatch.md]
-  [218]:ManualDispatch: ActiveSupport::BroadcastLogger#respond_to_missing? manually dispatches method call [https://github.com/troessner/reek/blob/v6.3.0/docs/Manual-Dispatch.md]
-  [183]:TooManyStatements: ActiveSupport::BroadcastLogger#dispatch has approx 7 statements [https://github.com/troessner/reek/blob/v6.3.0/docs/Too-Many-Statements.md]
-  [205]:TooManyStatements: ActiveSupport::BroadcastLogger#method_missing has approx 6 statements [https://github.com/troessner/reek/blob/v6.3.0/docs/Too-Many-Statements.md]
 lib/activesupport/isolated_execution_state.rb -- 4 warnings:
   [7]:Attribute: ActiveSupport::IsolatedExecutionState#active_support_execution_state is a writable attribute [https://github.com/troessner/reek/blob/v6.3.0/docs/Attribute.md]
   [8]:Attribute: ActiveSupport::IsolatedExecutionState#active_support_execution_state is a writable attribute [https://github.com/troessner/reek/blob/v6.3.0/docs/Attribute.md]
@@ -30,4 +24,4 @@ lib/activesupport/logger_silence.rb -- 1 warning:
   [9]:IrresponsibleModule: ActiveSupport::LoggerSilence has no descriptive comment [https://github.com/troessner/reek/blob/v6.3.0/docs/Irresponsible-Module.md]
 lib/activesupport/logger_thread_safe_level.rb -- 1 warning:
   [20, 24]:NilCheck: ActiveSupport::LoggerThreadSafeLevel#local_level= performs a nil-check [https://github.com/troessner/reek/blob/v6.3.0/docs/Nil-Check.md]
-25 total warnings
+19 total warnings

--- a/lib/activesupport/logger/version.rb
+++ b/lib/activesupport/logger/version.rb
@@ -6,7 +6,7 @@
 module Activesupport
   module Logger
     module Version
-      VERSION = "2.0.0"
+      VERSION = "2.0.1"
     end
   end
 end


### PR DESCRIPTION
## [2.0.1] - 2024-11-21
- COVERAGE:  95.50% -- 106/111 lines in 6 files
- BRANCH COVERAGE:  84.00% -- 21/25 branches in 6 files
- 44.83% documented
### Added
- More tests lifted from Rails v8.0 test suite
### Fixed
- Compatibility with ActiveSupport
  - Many libraries do `require "active_support"`
